### PR TITLE
Fix unicode issues

### DIFF
--- a/lib/prawn_plus/template_handlers/prawn.rb
+++ b/lib/prawn_plus/template_handlers/prawn.rb
@@ -5,8 +5,8 @@ module PrawnPlus
     # Renderer for a Prawn template. Assumes the template will reference a _pdf_ (a.k.a.
     # Prawn:Document) instance.
     class Prawn
-      def call template, _source
-        "pdf = ::Prawn::Document.new;" + template.source + ";pdf.render;"
+      def call _template, source
+        "pdf = ::Prawn::Document.new;" + source + ";pdf.render;"
       end
     end
   end

--- a/spec/requests/unicode_spec.rb
+++ b/spec/requests/unicode_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Request unicode PDF", type: :request do
+  include Dummy::Application.routes.url_helpers
+  include Capybara::DSL
+
+  describe "#show" do
+    it "renders PDF for multiple languages" do
+      get unicode_path, headers: {accept: "application/pdf"}
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/support/dummy/app/controllers/unicode_controller.rb
+++ b/spec/support/dummy/app/controllers/unicode_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class UnicodeController < ApplicationController
+  def show
+  end
+end

--- a/spec/support/dummy/app/views/unicode/show.pdf.prawn
+++ b/spec/support/dummy/app/views/unicode/show.pdf.prawn
@@ -1,0 +1,5 @@
+# Danish and Norweigan
+pdf.text "æøåÆØÅ"
+
+# Swedish
+pdf.text "åäöÅÄÖ"

--- a/spec/support/dummy/config/routes.rb
+++ b/spec/support/dummy/config/routes.rb
@@ -3,4 +3,5 @@
 Rails.application.routes.draw do
   root to: "documents#index"
   resources :documents
+  resource :unicode, controller: :unicode, only: [:show]
 end


### PR DESCRIPTION
Swedish characters like åäö didn't work with prior version. `template.source` is stripped from all unicode characters but `source` is not.
